### PR TITLE
Auto-detect UUID primary keys for QueryLens tables

### DIFF
--- a/app/views/query_lens/queries/show.html.erb
+++ b/app/views/query_lens/queries/show.html.erb
@@ -730,17 +730,17 @@
     el.conversationList.querySelectorAll('.ql-conversation-item').forEach(item => {
       item.addEventListener('click', (e) => {
         if (e.target.closest('.ql-conversation-delete')) return;
-        loadConversation(parseInt(item.dataset.conversationId, 10));
+        loadConversation(item.dataset.conversationId);
       });
     });
 
     el.conversationList.querySelectorAll('.ql-conversation-delete').forEach(btn => {
       btn.addEventListener('click', async (e) => {
         e.stopPropagation();
-        const id = parseInt(btn.dataset.deleteId, 10);
+        const id = btn.dataset.deleteId;
         try {
           await request(conversationsUrl + '/' + id, 'DELETE');
-          if (currentConversationId === id) startNewChat();
+          if (String(currentConversationId) === String(id)) startNewChat();
           loadConversations();
         } catch (e) { /* silently fail */ }
       });
@@ -1093,12 +1093,11 @@
   }
 
   function findQuery(id) {
-    id = parseInt(id, 10);
     for (const p of savedData.projects) {
-      const q = p.saved_queries.find(q => q.id === id);
+      const q = p.saved_queries.find(q => String(q.id) === String(id));
       if (q) return q;
     }
-    return savedData.unorganized.find(q => q.id === id);
+    return savedData.unorganized.find(q => String(q.id) === String(id));
   }
 })();
 </script>

--- a/lib/generators/query_lens/install/install_generator.rb
+++ b/lib/generators/query_lens/install/install_generator.rb
@@ -23,12 +23,21 @@ module QueryLens
       def show_post_install
         say ""
         say "QueryLens installed successfully!", :green
+        if uuid?
+          say "  Detected UUID primary keys — using UUID for all QueryLens tables.", :cyan
+        end
         say ""
         say "Next steps:"
         say "  1. Run `rails db:migrate` to create QueryLens tables"
         say "  2. Set your ANTHROPIC_API_KEY environment variable"
         say "  3. Visit /query_lens in your browser"
         say ""
+      end
+
+      private
+
+      def uuid?
+        Rails.application.config.generators.options.dig(:active_record, :primary_key_type).to_s == "uuid"
       end
     end
   end

--- a/lib/generators/query_lens/install/templates/create_query_lens_tables.rb.tt
+++ b/lib/generators/query_lens/install/templates/create_query_lens_tables.rb.tt
@@ -1,6 +1,6 @@
 class CreateQueryLensTables < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    create_table :query_lens_projects do |t|
+    create_table :query_lens_projects<%= ", id: :uuid" if uuid? %> do |t|
       t.string :name, null: false
       t.text :description
       t.integer :position
@@ -9,18 +9,18 @@ class CreateQueryLensTables < ActiveRecord::Migration[<%= ActiveRecord::Migratio
 
     add_index :query_lens_projects, :name, unique: true
 
-    create_table :query_lens_saved_queries do |t|
+    create_table :query_lens_saved_queries<%= ", id: :uuid" if uuid? %> do |t|
       t.string :name, null: false
       t.text :description
       t.text :sql, null: false
-      t.references :project, foreign_key: { to_table: :query_lens_projects, on_delete: :nullify }
+      t.references :project, type: :<%= uuid? ? "uuid" : "bigint" %>, foreign_key: { to_table: :query_lens_projects, on_delete: :nullify }
       t.integer :position
       t.timestamps
     end
 
     add_index :query_lens_saved_queries, [:project_id, :name], unique: true
 
-    create_table :query_lens_conversations do |t|
+    create_table :query_lens_conversations<%= ", id: :uuid" if uuid? %> do |t|
       t.string :title, null: false
       t.text :messages
       t.text :last_sql

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -44,6 +44,28 @@ class QueryLens::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "migration uses default bigint primary keys when app does not use uuid" do
+    run_generator
+    assert_migration "db/migrate/create_query_lens_tables.rb" do |content|
+      refute_match(/id: :uuid/, content)
+      assert_match(/type: :bigint/, content)
+    end
+  end
+
+  test "migration auto-detects uuid from app config" do
+    # Simulate app configured with UUID primary keys
+    original = Rails.application.config.generators.options.deep_dup
+    Rails.application.config.generators.options[:active_record] = { primary_key_type: :uuid }
+
+    run_generator
+    assert_migration "db/migrate/create_query_lens_tables.rb" do |content|
+      assert_match(/id: :uuid/, content)
+      assert_match(/type: :uuid/, content)
+    end
+  ensure
+    Rails.application.config.generators.options.replace(original)
+  end
+
   private
 
   def create_empty_routes_file


### PR DESCRIPTION
## Summary

- Auto-detects `primary_key_type: :uuid` from the host app's generator config
- Migration template conditionally uses `id: :uuid` on all three tables and matching `type: :uuid` on the `project` foreign key
- No flags needed — `rails generate query_lens:install` just works

## Context

Apps that enforce UUID primary keys globally (via `config.generators { |g| g.orm :active_record, primary_key_type: :uuid }`) get integer PKs from the current migration template, causing type mismatches and broken links.

## Test plan

- [x] Existing tests pass (101 runs, 0 failures)
- [x] New test: migration uses bigint by default
- [x] New test: migration auto-detects UUID from app config