### PR TITLE
Add Snowflake support with UI source selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add Snowflake support via [rb-snowflake-client](https://github.com/rinsed-org/rb-snowflake-client) — configure a Snowflake client to query warehouses with the same natural language interface
+- Schema introspection for Snowflake via `INFORMATION_SCHEMA` (tables, columns, row counts, primary keys)
+- Snowflake-specific SQL dialect hints in AI system prompt (ILIKE, DATE_TRUNC, QUALIFY, FLATTEN, etc.)
+- New configuration options: `snowflake_client`, `snowflake_database`, `snowflake_schema`, `snowflake_warehouse`, `snowflake_role`
+
 ## 0.2.0 — 2026-02-15
 
 - Add Chart.js charting to query results with a Table/Chart toggle

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Audit logging is fail-safe: if your logger raises an error, the query still exec
 
 ### Snowflake
 
-QueryLens can query Snowflake data warehouses using [rb-snowflake-client](https://github.com/rinsed-org/rb-snowflake-client). When configured, all queries and schema introspection go through the Snowflake HTTP API instead of ActiveRecord.
+QueryLens can query Snowflake data warehouses using [rb-snowflake-client](https://github.com/rinsed-org/rb-snowflake-client). When configured, a data source selector appears in the SQL Editor toolbar, letting users switch between your Rails database and Snowflake.
 
 Add the gem to your Gemfile:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Powered by [RubyLLM](https://rubyllm.com), QueryLens works with any major AI pro
 - Editable SQL editor with syntax highlighting
 - Results displayed as sortable tables with **Chart.js charting** (bar, line, pie, scatter) and auto-detected chart types
 - Configurable authentication, timeouts, and row limits
+- **Snowflake support** via [rb-snowflake-client](https://github.com/rinsed-org/rb-snowflake-client) — query Snowflake warehouses with the same natural language interface
 - Zero frontend dependencies (self-contained CSS, vanilla JS)
 
 ## Installation
@@ -224,6 +225,40 @@ Actions logged:
 - `generate_error` — AI generation failed
 
 Audit logging is fail-safe: if your logger raises an error, the query still executes normally and the failure is logged to `Rails.logger.error`.
+
+### Snowflake
+
+QueryLens can query Snowflake data warehouses using [rb-snowflake-client](https://github.com/rinsed-org/rb-snowflake-client). When configured, all queries and schema introspection go through the Snowflake HTTP API instead of ActiveRecord.
+
+Add the gem to your Gemfile:
+
+```ruby
+gem "rb-snowflake-client"
+```
+
+Then configure QueryLens:
+
+```ruby
+QueryLens.configure do |config|
+  config.snowflake_client = RubySnowflake::Client.new(
+    "https://your-account.snowflakecomputing.com",
+    File.read("path/to/rsa_key.p8"),
+    "your-org",
+    "your-account",
+    "YOUR_USER"
+  )
+  config.snowflake_database = "MY_DATABASE"
+  config.snowflake_schema = "PUBLIC"
+  config.snowflake_warehouse = "MY_WAREHOUSE"
+  config.snowflake_role = "MY_ROLE"
+end
+```
+
+When Snowflake is configured:
+- Schema introspection queries `INFORMATION_SCHEMA` for tables, columns, and row counts
+- The AI receives Snowflake-specific SQL dialect hints (ILIKE, DATE_TRUNC, QUALIFY, etc.)
+- Query execution uses the Snowflake client directly — no ActiveRecord connection needed
+- All safety layers (SQL validation, excluded tables, row limits, audit logging) still apply
 
 ### Read-Only Connection (Recommended for Production)
 

--- a/app/controllers/query_lens/ai_controller.rb
+++ b/app/controllers/query_lens/ai_controller.rb
@@ -3,11 +3,12 @@ module QueryLens
     def generate
       messages = params[:messages] || []
       messages = messages.map { |m| m.permit(:role, :content).to_h }
+      source = params[:source] || "activerecord"
 
       started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-      schema = SchemaIntrospector.cached_schema
-      generator = SqlGenerator.new(schema: schema)
+      schema = SchemaIntrospector.cached_schema(source: source)
+      generator = SqlGenerator.new(schema: schema, source: source)
       result = generator.generate(messages: messages)
 
       elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round

--- a/app/controllers/query_lens/queries_controller.rb
+++ b/app/controllers/query_lens/queries_controller.rb
@@ -7,7 +7,8 @@ module QueryLens
       render json: {
         excluded_tables: QueryLens.configuration.excluded_tables,
         max_rows: QueryLens.configuration.max_rows,
-        query_timeout: QueryLens.configuration.query_timeout
+        query_timeout: QueryLens.configuration.query_timeout,
+        data_sources: QueryLens.configuration.data_sources
       }
     end
 
@@ -32,10 +33,12 @@ module QueryLens
         return render json: { error: "Multiple statements are not allowed" }, status: :unprocessable_entity
       end
 
-      # Layer 4: Block dangerous PostgreSQL functions
-      if sql.match?(/\b(pg_sleep|pg_terminate_backend|pg_cancel_backend|lo_import|lo_export|copy\s)/i)
-        audit(action: "execute_blocked", sql: sql, error: "Dangerous function detected")
-        return render json: { error: "This function is not allowed" }, status: :unprocessable_entity
+      # Layer 4: Block dangerous PostgreSQL functions (skip for Snowflake)
+      unless params[:source] == "snowflake"
+        if sql.match?(/\b(pg_sleep|pg_terminate_backend|pg_cancel_backend|lo_import|lo_export|copy\s)/i)
+          audit(action: "execute_blocked", sql: sql, error: "Dangerous function detected")
+          return render json: { error: "This function is not allowed" }, status: :unprocessable_entity
+        end
       end
 
       # Layer 5: Block queries against excluded tables
@@ -48,6 +51,56 @@ module QueryLens
         end
       end
 
+      if params[:source] == "snowflake" && QueryLens.configuration.snowflake?
+        execute_snowflake(sql)
+      else
+        execute_activerecord(sql)
+      end
+    end
+
+    private
+
+    def execute_snowflake(sql)
+      config = QueryLens.configuration
+      client = config.snowflake_client
+
+      begin
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        result = client.query(
+          sql,
+          warehouse: config.snowflake_warehouse,
+          database: config.snowflake_database,
+          schema: config.snowflake_schema,
+          role: config.snowflake_role,
+          query_timeout: config.query_timeout
+        )
+
+        columns = result.columns.map(&:to_s)
+        rows = result.map { |row| columns.map { |col| row[col] } }
+
+        elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round
+
+        max_rows = config.max_rows
+        truncated = rows.length > max_rows
+        rows = rows.first(max_rows) if truncated
+
+        audit(action: "execute", sql: sql, row_count: rows.length)
+
+        render json: {
+          columns: columns,
+          rows: rows,
+          row_count: rows.length,
+          truncated: truncated,
+          execution_ms: elapsed_ms
+        }
+      rescue => e
+        audit(action: "execute_error", sql: sql, error: e.message)
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+    end
+
+    def execute_activerecord(sql)
       connection = QueryLens.configuration.read_only_connection || ActiveRecord::Base.connection
       postgresql = connection.adapter_name.downcase.include?("postgresql")
       timeout = QueryLens.configuration.query_timeout

--- a/app/services/query_lens/schema_introspector.rb
+++ b/app/services/query_lens/schema_introspector.rb
@@ -171,13 +171,14 @@ module QueryLens
         "ORDER BY TABLE_NAME"
       )
 
+      all_table_names = tables.map { |t| t["TABLE_NAME"].downcase }
+
       tables.filter_map do |row|
         table_name = row["TABLE_NAME"]
         next if excluded.include?(table_name.downcase)
 
         columns = snowflake_introspect_columns(table_name)
         pk_columns = snowflake_primary_keys(table_name)
-        all_table_names = tables.map { |t| t["TABLE_NAME"].downcase }
 
         columns.each do |col|
           col[:primary_key] = pk_columns.include?(col[:name])

--- a/app/services/query_lens/schema_introspector.rb
+++ b/app/services/query_lens/schema_introspector.rb
@@ -21,37 +21,43 @@ module QueryLens
       query_lens_conversations
     ].freeze
 
-    # Schema cache: stores { schema: [...], generated_at: Time }
-    @cache = nil
+    # Schema cache: keyed by source, stores { schema: [...], generated_at: Time }
+    @caches = {}
     @cache_mutex = Mutex.new
 
     class << self
-      def cached_schema(connection: nil, ttl: nil)
+      def cached_schema(connection: nil, ttl: nil, source: "activerecord")
         ttl ||= QueryLens.configuration.schema_cache_ttl
 
         @cache_mutex.synchronize do
-          if @cache && (Time.now - @cache[:generated_at]) < ttl
-            return @cache[:schema]
+          cached = @caches[source]
+          if cached && (Time.now - cached[:generated_at]) < ttl
+            return cached[:schema]
           end
 
-          schema = new(connection: connection).introspect
-          @cache = { schema: schema, generated_at: Time.now }
+          schema = new(connection: connection, source: source).introspect
+          @caches[source] = { schema: schema, generated_at: Time.now }
           schema
         end
       end
 
       def clear_cache!
-        @cache_mutex.synchronize { @cache = nil }
+        @cache_mutex.synchronize { @caches = {} }
       end
     end
 
-    def initialize(connection: nil)
+    def initialize(connection: nil, source: "activerecord")
       @connection = connection || ActiveRecord::Base.connection
+      @source = source
     end
 
     def introspect
-      tables = @connection.tables - EXCLUDED_TABLES - QueryLens.configuration.excluded_tables
-      tables.sort.map { |table| introspect_table(table) }
+      if @source == "snowflake" && QueryLens.configuration.snowflake?
+        introspect_snowflake
+      else
+        tables = @connection.tables - EXCLUDED_TABLES - QueryLens.configuration.excluded_tables
+        tables.sort.map { |table| introspect_table(table) }
+      end
     end
 
     # Full schema prompt (all tables) — used for small schemas
@@ -151,6 +157,101 @@ module QueryLens
       end
     rescue
       0
+    end
+
+    # Snowflake-specific introspection
+
+    def introspect_snowflake
+      config = QueryLens.configuration
+      excluded = EXCLUDED_TABLES + config.excluded_tables
+
+      tables = snowflake_query(
+        "SELECT TABLE_NAME, ROW_COUNT FROM INFORMATION_SCHEMA.TABLES " \
+        "WHERE TABLE_SCHEMA = '#{config.snowflake_schema}' AND TABLE_TYPE = 'BASE TABLE' " \
+        "ORDER BY TABLE_NAME"
+      )
+
+      tables.filter_map do |row|
+        table_name = row["TABLE_NAME"]
+        next if excluded.include?(table_name.downcase)
+
+        columns = snowflake_introspect_columns(table_name)
+        pk_columns = snowflake_primary_keys(table_name)
+        all_table_names = tables.map { |t| t["TABLE_NAME"].downcase }
+
+        columns.each do |col|
+          col[:primary_key] = pk_columns.include?(col[:name])
+        end
+
+        foreign_keys = snowflake_infer_foreign_keys(columns, all_table_names)
+
+        {
+          name: table_name,
+          columns: columns,
+          foreign_keys: foreign_keys,
+          approximate_row_count: row["ROW_COUNT"].to_i
+        }
+      end
+    end
+
+    def snowflake_introspect_columns(table_name)
+      config = QueryLens.configuration
+      rows = snowflake_query(
+        "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT " \
+        "FROM INFORMATION_SCHEMA.COLUMNS " \
+        "WHERE TABLE_SCHEMA = '#{config.snowflake_schema}' AND TABLE_NAME = '#{table_name}' " \
+        "ORDER BY ORDINAL_POSITION"
+      )
+
+      rows.map do |row|
+        {
+          name: row["COLUMN_NAME"],
+          type: row["DATA_TYPE"],
+          null: row["IS_NULLABLE"] == "YES",
+          default: row["COLUMN_DEFAULT"],
+          primary_key: false
+        }
+      end
+    end
+
+    def snowflake_primary_keys(table_name)
+      config = QueryLens.configuration
+      rows = snowflake_query(
+        "SELECT kcu.COLUMN_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc " \
+        "JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu " \
+        "ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME " \
+        "AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA " \
+        "AND tc.TABLE_NAME = kcu.TABLE_NAME " \
+        "WHERE tc.TABLE_SCHEMA = '#{config.snowflake_schema}' " \
+        "AND tc.TABLE_NAME = '#{table_name}' " \
+        "AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY'"
+      )
+      rows.map { |r| r["COLUMN_NAME"] }
+    rescue
+      []
+    end
+
+    def snowflake_infer_foreign_keys(columns, all_table_names)
+      fk_columns = columns.select { |c| c[:name].downcase.end_with?("_id") }
+
+      fk_columns.filter_map do |col|
+        referenced_table = col[:name].downcase.sub(/_id$/, "").pluralize
+        if all_table_names.include?(referenced_table)
+          { column: col[:name], to_table: referenced_table.upcase, primary_key: "ID" }
+        end
+      end
+    end
+
+    def snowflake_query(sql)
+      config = QueryLens.configuration
+      result = config.snowflake_client.query(
+        sql,
+        warehouse: config.snowflake_warehouse,
+        database: config.snowflake_database,
+        schema: config.snowflake_schema,
+        role: config.snowflake_role
+      )
+      result.map { |row| row.to_h.transform_keys(&:to_s) }
     end
   end
 end

--- a/app/services/query_lens/sql_generator.rb
+++ b/app/services/query_lens/sql_generator.rb
@@ -17,10 +17,24 @@ module QueryLens
       - When the user asks for data or wants a new/modified query: respond with a brief explanation (1-2 sentences), then the SQL query wrapped in ```sql code fences.
       - When the user asks about the results, asks what a column means, wants clarification, or is discussing the data: respond conversationally WITHOUT SQL code fences. The existing query and results will remain visible.
       - Only include ```sql code fences when you are providing a new or modified query.
-
+      %{dialect_hints}
       DATABASE SCHEMA:
       %{schema}
     PROMPT
+
+    SNOWFLAKE_HINTS = <<~HINTS
+
+      SNOWFLAKE SQL DIALECT:
+      - Use ILIKE for case-insensitive string matching instead of LOWER(col) LIKE.
+      - Use DATE_TRUNC('month', col) for date truncation (first argument is the part as a string).
+      - Use DATEADD(day, N, col) and DATEDIFF(day, start, end) for date arithmetic.
+      - Use TRY_CAST(col AS type) instead of CAST when type conversion might fail.
+      - Use QUALIFY with window functions to filter without subqueries (e.g., QUALIFY ROW_NUMBER() OVER (...) = 1).
+      - Use LIMIT for row limiting (not TOP).
+      - String concatenation uses || operator.
+      - Use FLATTEN(input => col) for semi-structured data (VARIANT/ARRAY/OBJECT columns).
+      - Use col:key syntax to access nested fields in VARIANT columns.
+    HINTS
 
     TABLE_SELECTION_PROMPT = <<~PROMPT
       You are a database schema analyst. Given a list of tables and a user's question, identify which tables are needed to answer the question.
@@ -35,9 +49,10 @@ module QueryLens
       %{compact_index}
     PROMPT
 
-    def initialize(schema:, model: nil)
+    def initialize(schema:, model: nil, source: "activerecord")
       @schema = schema
       @model = model || QueryLens.configuration.model
+      @source = source
     end
 
     def generate(messages:)
@@ -60,7 +75,8 @@ module QueryLens
     def generate_single_stage(messages, schema_prompt)
       system = SYSTEM_PROMPT % {
         schema: schema_prompt,
-        max_rows: QueryLens.configuration.max_rows
+        max_rows: QueryLens.configuration.max_rows,
+        dialect_hints: @source == "snowflake" ? SNOWFLAKE_HINTS : ""
       }
 
       chat = RubyLLM.chat(model: @model)

--- a/app/views/query_lens/layouts/application.html.erb
+++ b/app/views/query_lens/layouts/application.html.erb
@@ -331,10 +331,23 @@
       display: flex; align-items: center; justify-content: space-between;
       padding: 12px 20px; border-bottom: 1px solid #27272a;
     }
+    .ql-editor-title-row {
+      display: flex; align-items: center; gap: 10px;
+    }
     .ql-editor-title {
       font-size: 12px; font-weight: 600; color: #71717a;
       text-transform: uppercase; letter-spacing: 0.06em;
     }
+    .ql-source-select {
+      padding: 4px 26px 4px 8px; font-size: 11px; font-family: inherit;
+      background: #0f0f12; color: #d4d4d8; border: 1px solid #3f3f46;
+      border-radius: 5px; outline: none; cursor: pointer;
+      appearance: none; -webkit-appearance: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%2371717a'/%3E%3C/svg%3E");
+      background-repeat: no-repeat; background-position: right 8px center;
+      transition: border-color 0.15s;
+    }
+    .ql-source-select:focus { border-color: #6366f1; }
     .ql-editor-actions {
       display: flex; align-items: center; gap: 8px;
     }

--- a/app/views/query_lens/queries/show.html.erb
+++ b/app/views/query_lens/queries/show.html.erb
@@ -102,7 +102,11 @@
       <!-- SQL Editor -->
       <div class="ql-editor-section">
         <div class="ql-editor-toolbar">
-          <div class="ql-editor-title">SQL Editor</div>
+          <div class="ql-editor-title-row">
+            <div class="ql-editor-title">SQL Editor</div>
+            <select class="ql-source-select" id="ql-source-select" style="display:none;">
+            </select>
+          </div>
           <div class="ql-editor-actions">
             <button class="ql-save-btn" id="ql-save-query-btn">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
@@ -173,6 +177,7 @@
     savedSectionChevron: document.getElementById('ql-saved-section-chevron'),
     savedSectionContent: document.getElementById('ql-saved-section-content'),
     savedTotalCount: document.getElementById('ql-saved-total-count'),
+    sourceSelect: document.getElementById('ql-source-select'),
   };
 
   let conversation = [];
@@ -180,6 +185,7 @@
   let conversationsList = [];
   let chartInstance = null;
   let lastResultData = null;
+  let currentSource = 'activerecord';
 
   // ── Load restricted tables ──
   (async function loadInfo() {
@@ -192,6 +198,13 @@
           .map(t => '<span class="ql-restricted-tag">' + esc(t) + '</span>')
           .join('');
         el.restrictedBanner.style.display = 'block';
+      }
+      if (info.data_sources && info.data_sources.length > 1) {
+        el.sourceSelect.innerHTML = info.data_sources
+          .map(s => '<option value="' + esc(s.id) + '">' + esc(s.name) + '</option>')
+          .join('');
+        el.sourceSelect.style.display = '';
+        el.sourceSelect.addEventListener('change', () => { currentSource = el.sourceSelect.value; });
       }
     } catch (e) { /* silently fail */ }
   })();
@@ -231,7 +244,7 @@
     trace.push({ time: askTime, dot: 'blue', label: 'Question received' });
 
     try {
-      const data = await post(generateUrl, { messages: conversation });
+      const data = await post(generateUrl, { messages: conversation, source: currentSource });
       const genTime = new Date();
 
       if (data.error) {
@@ -296,7 +309,7 @@
     el.rowCount.textContent = '';
 
     try {
-      const data = await post(executeUrl, { sql });
+      const data = await post(executeUrl, { sql, source: currentSource });
       const execTime = new Date();
 
       if (data.error) {

--- a/lib/generators/query_lens/install/templates/initializer.rb
+++ b/lib/generators/query_lens/install/templates/initializer.rb
@@ -61,4 +61,18 @@ QueryLens.configure do |config|
 
   # Optional: Use a separate read-only database connection
   # config.read_only_connection = ActiveRecord::Base.connected_to(role: :reading) { ActiveRecord::Base.connection }
+
+  # Optional: Use Snowflake instead of ActiveRecord (requires rb-snowflake-client gem)
+  # config.snowflake_client = RubySnowflake::Client.new(
+  #   "https://your-account.snowflakecomputing.com",
+  #   File.read("path/to/rsa_key.p8"),
+  #   "your-org",
+  #   "your-account",
+  #   "YOUR_USER",
+  #   max_pool_size: 5
+  # )
+  # config.snowflake_database = "MY_DATABASE"
+  # config.snowflake_schema = "PUBLIC"
+  # config.snowflake_warehouse = "MY_WAREHOUSE"
+  # config.snowflake_role = "MY_ROLE"
 end

--- a/lib/query_lens/configuration.rb
+++ b/lib/query_lens/configuration.rb
@@ -3,7 +3,9 @@ module QueryLens
     attr_accessor :model, :max_rows, :query_timeout,
                   :excluded_tables, :authentication, :read_only_connection,
                   :schema_cache_ttl, :table_selection_threshold,
-                  :audit_logger, :current_user_method
+                  :audit_logger, :current_user_method,
+                  :snowflake_client, :snowflake_database, :snowflake_schema,
+                  :snowflake_warehouse, :snowflake_role
 
     def initialize
       @model = "claude-sonnet-4-5-20250929"
@@ -16,6 +18,21 @@ module QueryLens
       @table_selection_threshold = 50 # tables above this trigger two-stage generation
       @audit_logger = nil # lambda receiving { user:, action:, sql:, row_count:, error:, timestamp: }
       @current_user_method = :current_user # method name to call on controller to identify the user
+      @snowflake_client = nil
+      @snowflake_database = nil
+      @snowflake_schema = "PUBLIC"
+      @snowflake_warehouse = nil
+      @snowflake_role = nil
+    end
+
+    def snowflake?
+      snowflake_client.present?
+    end
+
+    def data_sources
+      sources = [{ id: "activerecord", name: "Database" }]
+      sources << { id: "snowflake", name: "Snowflake" } if snowflake?
+      sources
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds optional Snowflake data warehouse querying via [rb-snowflake-client](https://github.com/rinsed-org/rb-snowflake-client) alongside existing ActiveRecord support
- Users switch between data sources via a dropdown in the SQL Editor toolbar (only shown when Snowflake is configured)
- Schema introspection, query execution, and AI SQL generation are all source-aware with per-source caching

## Changes
- **Configuration**: `snowflake_client`, `snowflake_database`, `snowflake_schema`, `snowflake_warehouse`, `snowflake_role` options + `data_sources` helper
- **Query execution**: Routes to `execute_snowflake` or `execute_activerecord` based on `source` param; Layer 4 (pg functions) skipped for Snowflake
- **Schema introspection**: Snowflake path queries `INFORMATION_SCHEMA` for tables/columns/PKs/row counts; per-source cache
- **SQL generator**: Snowflake dialect hints (ILIKE, QUALIFY, DATE_TRUNC, FLATTEN, etc.) injected when source is Snowflake
- **UI**: Data source `<select>` in editor toolbar, hidden when only one source available; `source` sent with all API calls
- **Docs**: README Snowflake section, CHANGELOG, initializer template example

## Test plan
- [ ] Verify gem loads without `rb-snowflake-client` installed (optional dependency)
- [ ] Verify ActiveRecord path unchanged when no Snowflake configured (dropdown hidden, no regressions)
- [ ] Configure Snowflake client and verify source selector appears
- [ ] Test schema introspection against Snowflake `INFORMATION_SCHEMA`
- [ ] Test query execution through Snowflake client
- [ ] Test AI generation uses Snowflake dialect hints when Snowflake source selected
- [ ] Test switching between sources mid-session